### PR TITLE
Task/api 1125 unknown host exception

### DIFF
--- a/hand-of-queen-elizabeth/src/main/java/gov/va/api/health/queenelizabeth/ee/impl/ConnectionProvider.java
+++ b/hand-of-queen-elizabeth/src/main/java/gov/va/api/health/queenelizabeth/ee/impl/ConnectionProvider.java
@@ -4,6 +4,7 @@ import gov.va.api.health.queenelizabeth.ee.Eligibilities;
 import java.io.InputStream;
 import java.net.InetAddress;
 import java.net.URL;
+import java.net.UnknownHostException;
 import java.security.KeyStore;
 import java.security.SecureRandom;
 import javax.net.ssl.HttpsURLConnection;
@@ -75,7 +76,12 @@ public class ConnectionProvider {
       throw new Eligibilities.RequestFailed("E&E Url received is not https.");
     }
     String urlHost = enpointUrl.getHost();
-    InetAddress inetAddress = InetAddress.getByName(urlHost);
+    InetAddress inetAddress;
+    try {
+      inetAddress = InetAddress.getByName(urlHost);
+    } catch (UnknownHostException e) {
+      throw new Eligibilities.RequestFailed("Unknown Host");
+    }
     if (inetAddress.isAnyLocalAddress()
         || inetAddress.isLoopbackAddress()
         || inetAddress.isLinkLocalAddress()) {

--- a/hand-of-queen-elizabeth/src/test/java/gov/va/api/health/queenelizabeth/ee/impl/ConnectionProviderTest.java
+++ b/hand-of-queen-elizabeth/src/test/java/gov/va/api/health/queenelizabeth/ee/impl/ConnectionProviderTest.java
@@ -27,10 +27,18 @@ public class ConnectionProviderTest {
   @Test(expected = Eligibilities.RequestFailed.class)
   @SneakyThrows
   public void localhostGetsRequestFailed() {
-    // URL url = Mockito.spy(new URL("http://ee.va.gov:9334/getEESummary/"));
     ConnectionProvider connectionProvider =
         new ConnectionProvider(
             new URL("https://localhost:9334/getEESummary/"), "test-truststore.jks", "secret");
+    connectionProvider.getConnection();
+  }
+
+  @Test(expected = Eligibilities.RequestFailed.class)
+  @SneakyThrows
+  public void unknownHostGetsRequestFailed() {
+    ConnectionProvider connectionProvider =
+        new ConnectionProvider(
+            new URL("https://ee.va.gov:9334/getEESummary/"), "test-truststore.jks", "secret");
     connectionProvider.getConnection();
   }
 }


### PR DESCRIPTION
[API-1125](https://vasdvp.atlassian.net/browse/API-1125)

The failures that were occuring in QA were all unknown host but gave 'undeclaredthrowableexception'

* Throw a request failed on unknown host
* Added a test to test new code

To test locally, run Queen Elizabeth while not connected to the VPN. The message that comes back should now be "Reason: Unknown Host"