### PR TITLE
Remove ICN restriction

### DIFF
--- a/ee-artifacts/pom.xml
+++ b/ee-artifacts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>health-apis-parent</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.2</version>
     <relativePath/>
   </parent>
   <artifactId>ee-artifacts</artifactId>

--- a/hand-of-queen-elizabeth/pom.xml
+++ b/hand-of-queen-elizabeth/pom.xml
@@ -11,7 +11,7 @@
   <version>1.1.37-SNAPSHOT</version>
   <packaging>jar</packaging>
   <properties>
-    <jacoco.coverage>0.85</jacoco.coverage>
+    <jacoco.coverage>0.84</jacoco.coverage>
   </properties>
   <dependencies>
     <dependency>

--- a/hand-of-queen-elizabeth/pom.xml
+++ b/hand-of-queen-elizabeth/pom.xml
@@ -4,14 +4,14 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>api-starter</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.2</version>
     <relativePath/>
   </parent>
   <artifactId>hand-of-queen-elizabeth</artifactId>
   <version>1.1.37-SNAPSHOT</version>
   <packaging>jar</packaging>
   <properties>
-    <jacoco.coverage>0.84</jacoco.coverage>
+    <jacoco.coverage>0.85</jacoco.coverage>
   </properties>
   <dependencies>
     <dependency>

--- a/hand-of-queen-elizabeth/src/main/java/gov/va/api/health/queenelizabeth/ee/Eligibilities.java
+++ b/hand-of-queen-elizabeth/src/main/java/gov/va/api/health/queenelizabeth/ee/Eligibilities.java
@@ -40,10 +40,4 @@ public interface Eligibilities {
       super(" Reason: " + message);
     }
   }
-
-  class UnknownIdentityInSearchParameter extends EligibilitiesException {
-    public UnknownIdentityInSearchParameter(SoapMessageGenerator soapMessageGenerator) {
-      super(soapMessageGenerator.createGetEeSummarySoapRequest().toString());
-    }
-  }
 }

--- a/hand-of-queen-elizabeth/src/main/java/gov/va/api/health/queenelizabeth/ee/impl/ValidateEligibilities.java
+++ b/hand-of-queen-elizabeth/src/main/java/gov/va/api/health/queenelizabeth/ee/impl/ValidateEligibilities.java
@@ -45,9 +45,6 @@ public class ValidateEligibilities implements Eligibilities {
     if (soapMessageGenerator.id().isEmpty()) {
       throw new MissingIcnValue(soapMessageGenerator);
     }
-    if (!soapMessageGenerator.id().matches("[0-9]{10,16}V[0-9]{6,12}")) {
-      throw new UnknownIdentityInSearchParameter(soapMessageGenerator);
-    }
   }
 
   private String write(SoapMessageGenerator soapMessageGenerator, Document xml) {

--- a/hand-of-queen-elizabeth/src/test/java/gov/va/api/health/queenelizabeth/ee/impl/ValidateEligibilitiesTest.java
+++ b/hand-of-queen-elizabeth/src/test/java/gov/va/api/health/queenelizabeth/ee/impl/ValidateEligibilitiesTest.java
@@ -38,16 +38,6 @@ public class ValidateEligibilitiesTest {
             .build());
   }
 
-  @Test(expected = Eligibilities.UnknownIdentityInSearchParameter.class)
-  public void invalidIcnIdShouldReturnUnknownIdentityException() {
-    validateEligibilities.request(
-        SoapMessageGenerator.builder()
-            .eeUsername("eeTestUsername")
-            .eePassword("eeTestPassword")
-            .eeRequestName("eeTestRequestName")
-            .id("not-an-icn")
-            .build());
-  }
 
   @Test(expected = Eligibilities.RequestFailed.class)
   public void requestFailedForFailedParse() {

--- a/hand-of-queen-elizabeth/src/test/java/gov/va/api/health/queenelizabeth/ee/impl/ValidateEligibilitiesTest.java
+++ b/hand-of-queen-elizabeth/src/test/java/gov/va/api/health/queenelizabeth/ee/impl/ValidateEligibilitiesTest.java
@@ -38,7 +38,6 @@ public class ValidateEligibilitiesTest {
             .build());
   }
 
-
   @Test(expected = Eligibilities.RequestFailed.class)
   public void requestFailedForFailedParse() {
     Mockito.doReturn("<not-valid-xml>")

--- a/lombok-xjc-plugin/pom.xml
+++ b/lombok-xjc-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>health-apis-parent</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.2</version>
     <relativePath/>
   </parent>
   <artifactId>lombok-xjc-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>health-apis-parent</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.2</version>
   </parent>
   <artifactId>ee-apis-parent</artifactId>
   <version>1.1.37-SNAPSHOT</version>

--- a/queen-elizabeth/pom.xml
+++ b/queen-elizabeth/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>service-starter</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.2</version>
     <relativePath/>
   </parent>
   <artifactId>queen-elizabeth</artifactId>

--- a/queen-elizabeth/src/main/java/gov/va/api/health/queenelizabeth/controller/WebExceptionHandler.java
+++ b/queen-elizabeth/src/main/java/gov/va/api/health/queenelizabeth/controller/WebExceptionHandler.java
@@ -25,12 +25,6 @@ public class WebExceptionHandler {
     return responseFor(e);
   }
 
-  @ExceptionHandler({Eligibilities.UnknownIdentityInSearchParameter.class})
-  @ResponseStatus(HttpStatus.NOT_FOUND)
-  public ErrorResponse handleNotFound(Exception e) {
-    return responseFor(e);
-  }
-
   @ExceptionHandler({Exception.class})
   @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
   public ErrorResponse handleSnafu(Exception e) {

--- a/queen-elizabeth/src/test/java/gov/va/api/health/queenelizabeth/controller/WebExceptionHandlerTest.java
+++ b/queen-elizabeth/src/test/java/gov/va/api/health/queenelizabeth/controller/WebExceptionHandlerTest.java
@@ -56,9 +56,6 @@ public class WebExceptionHandlerTest {
             .id("1010101010V666666")
             .build();
     return Arrays.asList(
-        test(
-            HttpStatus.NOT_FOUND,
-            new Eligibilities.UnknownIdentityInSearchParameter(soapMessageGenerator)),
         test(HttpStatus.BAD_REQUEST, new Eligibilities.MissingIcnValue(soapMessageGenerator)),
         test(
             HttpStatus.BAD_REQUEST,


### PR DESCRIPTION
https://vasdvp.atlassian.net/browse/CCE-29
No longer check the validity of an ICN before calling out to E&E, allowing us to use all ICN values coming from the mock-ee DB
