### PR TITLE
Task/cer 76 fortify unreleased resource streams

### DIFF
--- a/hand-of-queen-elizabeth/src/main/java/gov/va/api/health/queenelizabeth/ee/impl/ConnectionProvider.java
+++ b/hand-of-queen-elizabeth/src/main/java/gov/va/api/health/queenelizabeth/ee/impl/ConnectionProvider.java
@@ -67,10 +67,8 @@ public class ConnectionProvider {
   @SneakyThrows
   SSLContext getSslContext() {
     /* Load the truststore that contains the ee certs. */
-    InputStream truststoreInputStream = null;
-    try {
-      truststoreInputStream =
-          ConnectionProvider.class.getResourceAsStream(FilenameUtils.getName(truststorePath));
+    try (InputStream truststoreInputStream =
+        ConnectionProvider.class.getResourceAsStream(FilenameUtils.getName(truststorePath))) {
       KeyStore ts = KeyStore.getInstance("JKS");
       ts.load(truststoreInputStream, truststorePassword.toCharArray());
       TrustManagerFactory trustManagerFactory =
@@ -80,10 +78,6 @@ public class ConnectionProvider {
       SSLContext sslContext = SSLContext.getInstance("TLS");
       sslContext.init(null, trustManagerFactory.getTrustManagers(), new SecureRandom());
       return sslContext;
-    } finally {
-      if (truststoreInputStream != null) {
-        truststoreInputStream.close();
-      }
     }
   }
 }

--- a/hand-of-queen-elizabeth/src/main/java/gov/va/api/health/queenelizabeth/ee/impl/ConnectionProvider.java
+++ b/hand-of-queen-elizabeth/src/main/java/gov/va/api/health/queenelizabeth/ee/impl/ConnectionProvider.java
@@ -67,17 +67,23 @@ public class ConnectionProvider {
   @SneakyThrows
   SSLContext getSslContext() {
     /* Load the truststore that contains the ee certs. */
-    InputStream truststoreInputStream =
-        getClass().getClassLoader().getResourceAsStream(FilenameUtils.getName(truststorePath));
-    KeyStore ts = KeyStore.getInstance("JKS");
-    ts.load(truststoreInputStream, truststorePassword.toCharArray());
-    TrustManagerFactory trustManagerFactory =
-        TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-    trustManagerFactory.init(ts);
-    /* Initialize the ssl context using the truststore. */
-    SSLContext sslContext = SSLContext.getInstance("TLS");
-    sslContext.init(null, trustManagerFactory.getTrustManagers(), new SecureRandom());
-    truststoreInputStream.close();
-    return sslContext;
+    InputStream truststoreInputStream = null;
+    try {
+      truststoreInputStream =
+          getClass().getClassLoader().getResourceAsStream(FilenameUtils.getName(truststorePath));
+      KeyStore ts = KeyStore.getInstance("JKS");
+      ts.load(truststoreInputStream, truststorePassword.toCharArray());
+      TrustManagerFactory trustManagerFactory =
+          TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+      trustManagerFactory.init(ts);
+      /* Initialize the ssl context using the truststore. */
+      SSLContext sslContext = SSLContext.getInstance("TLS");
+      sslContext.init(null, trustManagerFactory.getTrustManagers(), new SecureRandom());
+      return sslContext;
+    } finally {
+      if (truststoreInputStream != null) {
+        truststoreInputStream.close();
+      }
+    }
   }
 }

--- a/hand-of-queen-elizabeth/src/main/java/gov/va/api/health/queenelizabeth/ee/impl/ConnectionProvider.java
+++ b/hand-of-queen-elizabeth/src/main/java/gov/va/api/health/queenelizabeth/ee/impl/ConnectionProvider.java
@@ -70,7 +70,7 @@ public class ConnectionProvider {
     InputStream truststoreInputStream = null;
     try {
       truststoreInputStream =
-          getClass().getClassLoader().getResourceAsStream(FilenameUtils.getName(truststorePath));
+          ConnectionProvider.class.getResourceAsStream(FilenameUtils.getName(truststorePath));
       KeyStore ts = KeyStore.getInstance("JKS");
       ts.load(truststoreInputStream, truststorePassword.toCharArray());
       TrustManagerFactory trustManagerFactory =


### PR DESCRIPTION
Covers these two Fortify issues:
Streams: https://vasdvp.atlassian.net/browse/CER-74
Null check: https://vasdvp.atlassian.net/browse/CER-76

I don't feel great about the try and finally thing I put in for Fortify purposes. One of the Fortify issues was that getClassLoader() can return null so I just forced it to use the ConnectionProvider class which I think is just an explicit version of what was happening already?