### PR TITLE
Reverting to old class loader pattern with null check

### DIFF
--- a/hand-of-queen-elizabeth/src/test/java/gov/va/api/health/queenelizabeth/ee/impl/ConnectionProviderTest.java
+++ b/hand-of-queen-elizabeth/src/test/java/gov/va/api/health/queenelizabeth/ee/impl/ConnectionProviderTest.java
@@ -26,6 +26,11 @@ public class ConnectionProviderTest {
     assertThat(connectionProvider.getSslContext().getProtocol()).isEqualTo("TLS");
   }
 
+  @Test(expected = ConnectionProvider.ClassLoaderException.class)
+  public void throwingClassLoaderException() {
+    throw new ConnectionProvider.ClassLoaderException("This is a test");
+  }
+
   @Test(expected = Eligibilities.RequestFailed.class)
   @SneakyThrows
   public void unknownHostGetsRequestFailedForHttp() {


### PR DESCRIPTION
https://vasdvp.atlassian.net/browse/CER-78

I really don't like this null check into an exception (which should never happen), but I also couldn't figure out how to make ConnectionProvider.class work properly. From what I've seen our files look like they're configured correctly for loading from ConnectionProvider.class but a deployment to QA failed along with local testing.