### PR TITLE
Task/cer 82 fortify scan fix

### DIFF
--- a/hand-of-queen-elizabeth/src/main/java/gov/va/api/health/queenelizabeth/ee/impl/ConnectionProvider.java
+++ b/hand-of-queen-elizabeth/src/main/java/gov/va/api/health/queenelizabeth/ee/impl/ConnectionProvider.java
@@ -45,11 +45,6 @@ public class ConnectionProvider {
   /** Get HTTPS Connection to EE. */
   @SneakyThrows
   public SOAPConnection getConnection() {
-    try {
-      InetAddress.getByName(endpointUrl.getHost());
-    } catch (UnknownHostException e) {
-      throw new Eligibilities.RequestFailed("Unknown Host");
-    }
     if (endpointUrl.getProtocol().equals("http")) {
       urlConnection = (HttpURLConnection) endpointUrl.openConnection();
       urlConnection.connect();

--- a/hand-of-queen-elizabeth/src/main/java/gov/va/api/health/queenelizabeth/ee/impl/ConnectionProvider.java
+++ b/hand-of-queen-elizabeth/src/main/java/gov/va/api/health/queenelizabeth/ee/impl/ConnectionProvider.java
@@ -1,11 +1,8 @@
 package gov.va.api.health.queenelizabeth.ee.impl;
 
-import gov.va.api.health.queenelizabeth.ee.Eligibilities;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
-import java.net.InetAddress;
 import java.net.URL;
-import java.net.UnknownHostException;
 import java.security.KeyStore;
 import java.security.SecureRandom;
 import javax.net.ssl.HttpsURLConnection;
@@ -47,13 +44,11 @@ public class ConnectionProvider {
   public SOAPConnection getConnection() {
     if (endpointUrl.getProtocol().equals("http")) {
       urlConnection = (HttpURLConnection) endpointUrl.openConnection();
-      urlConnection.connect();
-
     } else {
       HttpsURLConnection.setDefaultSSLSocketFactory(getSslContext().getSocketFactory());
       urlConnection = (HttpsURLConnection) endpointUrl.openConnection();
-      urlConnection.connect();
     }
+    urlConnection.connect();
     SOAPConnectionFactory soapConnectionFactory = SOAPConnectionFactory.newInstance();
     soapConnection = soapConnectionFactory.createConnection();
     return soapConnection;

--- a/hand-of-queen-elizabeth/src/test/java/gov/va/api/health/queenelizabeth/ee/impl/ConnectionProviderTest.java
+++ b/hand-of-queen-elizabeth/src/test/java/gov/va/api/health/queenelizabeth/ee/impl/ConnectionProviderTest.java
@@ -2,7 +2,6 @@ package gov.va.api.health.queenelizabeth.ee.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import gov.va.api.health.queenelizabeth.ee.Eligibilities;
 import java.net.URL;
 import lombok.SneakyThrows;
 import org.junit.Before;
@@ -29,22 +28,5 @@ public class ConnectionProviderTest {
   @Test(expected = ConnectionProvider.ClassLoaderException.class)
   public void throwingClassLoaderException() {
     throw new ConnectionProvider.ClassLoaderException("This is a test");
-  }
-
-  @Test(expected = Eligibilities.RequestFailed.class)
-  @SneakyThrows
-  public void unknownHostGetsRequestFailedForHttp() {
-    ConnectionProvider connectionProvider =
-        new ConnectionProvider(new URL("http://ee.va.gov:9334/getEESummary/"), null, null);
-    connectionProvider.getConnection();
-  }
-
-  @Test(expected = Eligibilities.RequestFailed.class)
-  @SneakyThrows
-  public void unknownHostGetsRequestFailedForHttps() {
-    ConnectionProvider connectionProvider =
-        new ConnectionProvider(
-            new URL("https://ee.va.gov:9334/getEESummary/"), "test-truststore.jks", "secret");
-    connectionProvider.getConnection();
   }
 }


### PR DESCRIPTION
Fortify fix.
The following section was ONLY done to try to throw a better exception if we couldn't find the host.  This would happen if we didnt have connectivity or if we were not on the VA network. The fortify scan showed that .getByName() is bad.  Instead of trying to defend it a third time we are removing it and relevant tests.

```
    try {
      InetAddress.getByName(endpointUrl.getHost());
    } catch (UnknownHostException e) {
      throw new Eligibilities.RequestFailed("Unknown Host");
    }
```